### PR TITLE
Fix cursor position on toggling empty delimiters

### DIFF
--- a/math-delimiters.el
+++ b/math-delimiters.el
@@ -248,6 +248,7 @@ delimiters."
                    (backward-char (length to-close))
                    (unless (or math-delimiters-compressed-display-math
                                (equal to-close close))
+                     (beginning-of-line)
                      (backward-char 1))))
         (cond
           ((use-region-p)


### PR DESCRIPTION
If `math-delimiters-compressed-display-math` is `nil` and we are
toggling empty delimiters from inline to display math, the cursor ends
up in the wrong position.  For example, if `|` is the cursor, given the
situation

    \begin{Theorem}
        blah $|$ blah
    \end{Theorem}

invoking `math-delimiters-insert` would result in

    \begin{Theorem}
        blah
        \[

      | \]
        blah
    \end{Theorem}

However, what we actually want is

    \begin{Theorem}
        blah
        \[
            |
        \]
        blah
    \end{Theorem}

The simple fix is to make sure we are at the beginning of the line when
moving back to the final position.